### PR TITLE
Add script to check errors locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ install:
   - flutter doctor
 
 script:
-  - flutter format --dry-run --set-exit-if-changed .
-  - flutter analyze
-  - flutter test test
+  - ./check_project.sh
 
 cache:
   directories:

--- a/check_project.sh
+++ b/check_project.sh
@@ -1,0 +1,5 @@
+  #!/bin/bash
+  
+  flutter format --dry-run --set-exit-if-changed .
+  flutter analyze
+  flutter test test


### PR DESCRIPTION
Add a bash script to run the checks locally. This solves the problem of having to manually run multiple commands every time a change is made.

```bash
$ ./check_project.sh 
Analyzing flutter_sample...                                             
No issues found! (ran in 1.4s)
00:00 +0: /home/blackhatmonkey/workspace/test/flutter_sample/test/json_test.dart: (suite)                                                          
  Skip: Needs to be moved to bloc
00:00 +0 ~1: /home/blackhatmonkey/workspace/test/flutter_sample/test/widget_test.dart: (suite)                                                     
  Skip: Needs to be implemented
00:00 +0 ~2: All tests skipped.         
```