### PR TITLE
Add live API calls

### DIFF
--- a/lib/book_api_provider.dart
+++ b/lib/book_api_provider.dart
@@ -1,19 +1,33 @@
 import 'dart:convert';
 
-import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
 
 import 'api/api_result.dart';
 import 'api/book.dart';
 
 /// A class fetches the book details.
 class BookApiProvider {
-  Future<String> _fetchApiResult() async =>
-      rootBundle.loadString('assets/test.json');
+  static const _key = 'cGNUdTNGOGVxcUhtck1SZWo4R3pRYkkzM3YzcHdTVEcK';
 
   /// Fetches all the books in Hardcore Fiction category.
   Future<List<Book>> fetchHardcoreFictionBooks() async {
     final data = await _fetchApiResult();
     final Map<String, dynamic> parsedData = json.decode(data);
     return ApiResult.fromJson(parsedData).results.books;
+  }
+
+  Future<String> _fetchApiResult() async {
+    final decryptedKey = _decryptKey(_key);
+
+    final url =
+        'https://api.nytimes.com/svc/books/v3/lists/hardcover-fiction.json?api-key=$decryptedKey';
+    final response = await http.get(url);
+
+    return response.body;
+  }
+
+  String _decryptKey(String key) {
+    final bytes = base64.decode(key);
+    return utf8.decode(bytes);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.0+1
 dependencies:
   eva_icons_flutter: ^1.0.4
   cupertino_icons: ^0.1.2
+  http: ^0.12.0+2
   rxdart: ^0.22.1
   transparent_image: ^1.0.0
   flutter: 


### PR DESCRIPTION
Add live calls to NY Times book API instead of local json. This allows users to get the latest result.