### PR TITLE
Name fix

### DIFF
--- a/lib/login_form.dart
+++ b/lib/login_form.dart
@@ -68,17 +68,18 @@ class _LoginFormState extends State<LoginForm> {
         padding: const EdgeInsets.all(16),
         child: RaisedButton(
           onPressed: _onPressed,
-          child: const Text('Login', style: TextStyle(fontSize: 23)),
+          child: const Text('LOGIN', style: TextStyle(fontSize: 23)),
         ),
       );
 
   void _onPressed() {
     if (_formKey.currentState.validate()) {
       Navigator.pushReplacement(
-          _formKey.currentContext,
-          MaterialPageRoute<Widget>(
-            builder: _buildRoute,
-          ));
+        _formKey.currentContext,
+        MaterialPageRoute<Widget>(
+          builder: _buildRoute,
+        ),
+      );
     }
   }
 

--- a/lib/login_header.dart
+++ b/lib/login_header.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
+/// A class displaying the top section of the login page.
 class LoginHeader extends StatelessWidget {
+  /// Creates a top header.
   const LoginHeader({Key key}) : super(key: key);
 
   @override
@@ -22,10 +24,10 @@ class LoginHeader extends StatelessWidget {
     );
   }
 
-  Widget _buildText() => Padding(
-        padding: const EdgeInsets.only(top: 13, bottom: 64),
+  Widget _buildText() => const Padding(
+        padding: EdgeInsets.only(top: 16, bottom: 64),
         child: Text(
-          'BTR490 Books',
+          'The Library',
           textAlign: TextAlign.center,
           style: TextStyle(fontSize: 30, fontWeight: FontWeight.w700),
         ),

--- a/lib/my_home.dart
+++ b/lib/my_home.dart
@@ -25,13 +25,8 @@ class _MyHomeState extends State<MyHome> {
 
   @override
   Widget build(BuildContext context) => Scaffold(
-        appBar: _buildAppBar(),
         body: _buildBody(),
         bottomNavigationBar: _buildBottomNavigation(),
-      );
-
-  Widget _buildAppBar() => AppBar(
-        title: const Text('Book Store'),
       );
 
   Widget _buildBody() {

--- a/test/login_form_test.dart
+++ b/test/login_form_test.dart
@@ -25,7 +25,7 @@ void main() {
     final buttonFinder = find.byType(RaisedButton);
     expect(buttonFinder, findsOneWidget);
 
-    const buttonText = 'Login';
+    const buttonText = 'LOGIN';
     final buttonTextFinder = find.text(buttonText);
     expect(buttonTextFinder, findsOneWidget);
   });
@@ -33,7 +33,7 @@ void main() {
   testWidgets('Email and password error message smoke test', (tester) async {
     await tester.pumpWidget(widget);
 
-    final loginButtonFinder = find.text('Login');
+    final loginButtonFinder = find.text('LOGIN');
     await tester.tap(loginButtonFinder);
 
     await tester.pump();

--- a/test/login_header_test.dart
+++ b/test/login_header_test.dart
@@ -14,7 +14,7 @@ void main() {
     final iconFinder = find.byIcon(Icons.library_books);
     expect(iconFinder, findsOneWidget);
 
-    final textFinder = find.text('BTR490 Books');
+    final textFinder = find.text('The Library');
     expect(textFinder, findsOneWidget);
   });
 }


### PR DESCRIPTION
Fix the login header to indicate the correct app name. Remove the app bar in the home page because it didn't provide any value.